### PR TITLE
TD-400: Fix thrift failing to encode value because set is unordered (1)

### DIFF
--- a/src/tk_context_extractor_user_session_token.erl
+++ b/src/tk_context_extractor_user_session_token.erl
@@ -117,7 +117,7 @@ maybe_auth_access_list(#{resource_access := ResourceAccess}) ->
             ordsets:add_element(
                 #{
                     id => Key,
-                    roles => maps:get(<<"roles">>, Value)
+                    roles => ordsets:from_list(maps:get(<<"roles">>, Value))
                 },
                 Acc
             )

--- a/test/token_keeper_SUITE.erl
+++ b/test/token_keeper_SUITE.erl
@@ -431,7 +431,7 @@ authenticate_user_session_token_w_resource_access(C) ->
     SubjectEmail = <<"test@test.test">>,
     ResourceAccess = #{
         <<"api.2">> => #{
-            <<"roles">> => [<<"do.nothing">>]
+            <<"roles">> => [<<"do.2">>, <<"do.1">>]
         },
         <<"api.1">> => #{
             <<"roles">> => [<<"do.something">>]
@@ -450,7 +450,7 @@ authenticate_user_session_token_w_resource_access(C) ->
             exp => make_auth_expiration(42),
             access => [
                 {<<"api.1">>, [<<"do.something">>]},
-                {<<"api.2">>, [<<"do.nothing">>]}
+                {<<"api.2">>, [<<"do.1">>, <<"do.2">>]}
             ]
         }},
         Context


### PR DESCRIPTION
🍞